### PR TITLE
Add configuration for LGTM static code analyzer

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  python:
+    python_setup:
+      version: 3


### PR DESCRIPTION
LGTM uses Python 2 by default. Tell it to use Python 3.

Signed-off-by: Stefan Weil <sw@weilnetz.de>