### PR TITLE
Loading training and validation data on the fly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,25 @@ test-cpu-predict-and-eval-with-voting:
     - calamari-predict --files calamari_ocr/test/data/uw3_50lines/test/*.png --checkpoint calamari_models/antiqua_modern/*.ckpt.json
     - calamari-eval --gt calamari_ocr/test/data/uw3_50lines/test/*.gt.txt
 
+
+
+test-cpu-data-on-the-fly:
+  stage: test
+  script:
+    - set -e
+    - calamari-train --train_data_on_the_fly --files calamari_ocr/test/data/uw3_50lines/train/*.png --max_iters 10
+
+test-cpu-validation-data-on-the-fly:
+  stage: test
+  script:
+    - set -e
+    - calamari-train --train_data_on_the_fly --validation_data_on_the_fly --validation calamari_ocr/test/data/uw3_50lines/train/*.png --files calamari_ocr/test/data/uw3_50lines/train/*.png --max_iters 10 --early_stopping_frequency 5
+
+test-cpu-cross-fold-train-augmentation-data-on-the-fly:
+  stage: test
+  script:
+    - set -e
+    - calamari-cross-fold-train --train_data_on_the_fly --validation_data_on_the_fly --n_augmentation 5 --files calamari_ocr/test/data/uw3_50lines/train/*.png --n_folds 3 --best_models_dir tmp_best_models --max_iters 10
 test-cpu-predict-and-eval-with-voting-extended-prediction-data:
   stage: test
   script:

--- a/calamari_ocr/ocr/augmentation/__init__.py
+++ b/calamari_ocr/ocr/augmentation/__init__.py
@@ -1,0 +1,1 @@
+from .data_augmenter import DataAugmenter, SimpleDataAugmenter, NoopDataAugmenter

--- a/calamari_ocr/ocr/backends/backend_interface.py
+++ b/calamari_ocr/ocr/backends/backend_interface.py
@@ -1,6 +1,7 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 import random
 import numpy as np
+from .model_interface import ModelInterface
 
 
 class BackendInterface(ABC):
@@ -15,3 +16,7 @@ class BackendInterface(ABC):
             np.random.seed(seed)
 
         super().__init__()
+
+    @abstractmethod
+    def create_net(self, dataset, codec, restore, weights, graph_type, batch_size=-1) -> ModelInterface:
+        pass

--- a/calamari_ocr/ocr/backends/tensorflow_backend/tensorflow_backend.py
+++ b/calamari_ocr/ocr/backends/tensorflow_backend/tensorflow_backend.py
@@ -21,8 +21,11 @@ class TensorflowBackend(BackendInterface):
         self.weights = weights
         self.first_model = True
 
-    def create_net(self, restore, weights, graph_type, batch_size=-1):
-        model = TensorflowModel(self.network_proto, self.graph, self.session, graph_type, batch_size, reuse_weights=not self.first_model)
+    def create_net(self, dataset, codec, restore, weights, graph_type, batch_size=-1):
+        model = TensorflowModel(self.network_proto, self.graph, self.session, graph_type, batch_size,
+                                reuse_weights=not self.first_model,
+                                input_dataset=dataset,
+                                codec=codec)
         self.first_model = False
         if weights:
             model.load_weights(weights, restore_only_trainable=True)

--- a/calamari_ocr/ocr/codec.py
+++ b/calamari_ocr/ocr/codec.py
@@ -1,4 +1,22 @@
+from calamari_ocr.utils.multiprocessing import tqdm_wrapper
+from calamari_ocr.ocr.datasets import InputDataset
+
+from typing import List
+
+
 class Codec:
+    @staticmethod
+    def from_input_dataset(input_dataset: List[InputDataset], whitelist=set(), progress_bar=False):
+        chars = set(whitelist)
+        for ds in input_dataset:
+            if not ds:
+                continue
+            for text in tqdm_wrapper(ds.text_generator(), total=len(ds), desc="Computing codec", progress_bar=progress_bar):
+                for c in text:
+                    chars.add(c)
+
+        return Codec(sorted(list(chars)))
+
     @staticmethod
     def from_texts(texts, whitelist=set()):
         """Compute a codec from given text

--- a/calamari_ocr/ocr/datasets/__init__.py
+++ b/calamari_ocr/ocr/datasets/__init__.py
@@ -3,6 +3,7 @@ from .file_dataset import FileDataSet
 from .abbyy_dataset import AbbyyDataSet
 from .pagexml_dataset import PageXMLDataset
 from .dataset_factory import DataSetType, create_dataset
+from .input_dataset import InputDataset, RawInputDataset
 
 __all__ = [
     'DataSet',
@@ -13,4 +14,6 @@ __all__ = [
     'AbbyyDataSet',
     'PageXMLDataset',
     'create_dataset',
+    'InputDataset',
+    'RawInputDataset',
 ]

--- a/calamari_ocr/ocr/datasets/abbyy_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/abbyy_dataset/dataset.py
@@ -58,14 +58,17 @@ class AbbyyDataSet(DataSet):
                         "format": fo,
                     })
 
-    def _load_sample(self, sample):
+    def _load_sample(self, sample, text_only):
         image_path = sample["image_path"]
         line = sample["line"]
         text = None
+        img = None
         if self.mode == DataSetMode.EVAL or self.mode == DataSetMode.TRAIN:
             text = sample["format"].text
 
-        img = None
+        if text_only:
+            return img, text
+
         if self.mode == DataSetMode.TRAIN or self.mode == DataSetMode.PREDICT:
             img = np.array(Image.open(image_path))
 

--- a/calamari_ocr/ocr/datasets/file_dataset.py
+++ b/calamari_ocr/ocr/datasets/file_dataset.py
@@ -9,7 +9,7 @@ from .dataset import DataSet, DataSetMode
 
 class FileDataSet(DataSet):
     def __init__(self, mode: DataSetMode,
-                 images=list(), texts=list(),
+                 images=None, texts=None,
                  skip_invalid=False, remove_invalid=True,
                  non_existing_as_empty=False):
         """ Create a dataset from a list of files
@@ -33,6 +33,9 @@ class FileDataSet(DataSet):
                          skip_invalid=skip_invalid,
                          remove_invalid=remove_invalid)
         self._non_existing_as_empty = non_existing_as_empty
+
+        images = [] if images is None else images
+        texts = [] if texts is None else texts
 
         if mode == DataSetMode.PREDICT:
             texts = [None] * len(images)
@@ -77,9 +80,12 @@ class FileDataSet(DataSet):
                 "id": img_bn if image else text_bn,
             })
 
-    def _load_sample(self, sample):
-        return self._load_line(sample["image_path"]), \
-               self._load_gt_txt(sample["text_path"])
+    def _load_sample(self, sample, text_only):
+        if text_only:
+            return None, self._load_gt_txt(sample["text_path"])
+        else:
+            return self._load_line(sample["image_path"]), \
+                   self._load_gt_txt(sample["text_path"])
 
     def _load_gt_txt(self, gt_txt_path):
         if gt_txt_path is None:

--- a/calamari_ocr/ocr/datasets/input_dataset.py
+++ b/calamari_ocr/ocr/datasets/input_dataset.py
@@ -1,0 +1,125 @@
+from .dataset import DataSet, DataSetMode, RawDataSet
+from calamari_ocr.ocr.data_processing import DataPreprocessor
+from calamari_ocr.ocr.text_processing import TextProcessor
+from calamari_ocr.ocr.augmentation import DataAugmenter
+from typing import Generator, Tuple, List, Any
+import numpy as np
+
+
+def RawInputDataset(
+        mode: DataSetMode,
+        raw_datas, raw_texts, raw_params,
+        data_preprocessor, text_preprocessor,
+        data_augmenter=None, data_augmentation_amount=0
+):
+    dataset = InputDataset(RawDataSet(mode=mode, images=raw_datas, texts=raw_texts),
+                           data_preprocessor,
+                           text_preprocessor,
+                           data_augmenter, data_augmentation_amount
+                           )
+    dataset.preloaded_datas = raw_datas
+    dataset.preloaded_texts = raw_texts
+    dataset.preloaded_params = raw_params
+    return dataset
+
+
+class InputDataset:
+    def __init__(self,
+                 dataset: DataSet,
+                 data_preprocessor: DataPreprocessor,
+                 text_preprocessor: TextProcessor,
+                 data_augmenter: DataAugmenter = None,
+                 data_augmentation_amount: float = 0,
+                 skip_invalid_gt=True):
+        self.dataset = dataset
+        self.data_processor = data_preprocessor
+        self.text_processor = text_preprocessor
+        self.skip_invalid_gt = skip_invalid_gt
+        self.data_augmenter = data_augmenter
+        self.preloaded_datas = []
+        self.preloaded_texts = []
+        self.preloaded_params = []
+        self.data_augmentation_amount = data_augmentation_amount
+        self.generate_only_non_augmented = False
+
+        if data_augmenter and dataset.mode != DataSetMode.TRAIN:
+            raise Exception('Data augmentation is only supported for training, but got {} dataset instead'.format(dataset.mode))
+
+        if data_augmentation_amount > 0 and self.data_augmenter is None:
+            raise Exception('Requested data augmentation, but no data augmented provided. Use e. g. SimpleDataAugmenter')
+
+    def __len__(self):
+        return len(self.dataset.samples())
+
+    def preload(self, processes=1, progress_bar=False):
+        print("Preloading dataset type {} with size {}".format(self.dataset.mode, len(self)))
+        self.dataset.load_samples(processes=1, progress_bar=progress_bar)           # load data always with one thread
+        datas, txts = self.dataset.train_samples(skip_empty=self.skip_invalid_gt)
+
+        if self.text_processor:
+            texts = self.text_processor.apply(txts, processes=processes, progress_bar=progress_bar)
+        if self.data_processor:
+            datas, params = [list(a) for a in zip(*self.data_processor.apply(datas, processes=processes, progress_bar=progress_bar))]
+
+        self.preloaded_datas, self.preloaded_texts, self.preloaded_params = datas, texts, params
+
+        if self.dataset.mode == DataSetMode.TRAIN and self.data_augmentation_amount > 0:
+            abs_n_augs = int(self.data_augmentation_amount) if self.data_augmentation_amount >= 1 else int(self.data_augmentation_amount * len(self))
+            self.preloaded_datas, self.preloaded_texts \
+                = self.data_augmenter.augment_datas(datas, texts, n_augmentations=abs_n_augs,
+                                                    processes=processes, progress_bar=progress_bar)
+
+    def text_generator(self) -> Generator[str, None, None]:
+        if len(self.preloaded_texts) > 0:
+            for text in self.preloaded_texts:
+                yield text
+        else:
+            for sample in self.dataset.samples():
+                _, text = self.dataset.load_single_sample(sample, text_only=True)
+                if self.text_processor:
+                    text = self.text_processor.apply([text], 1, False)[0]
+                yield text
+
+    def generator(self) -> Generator[Tuple[np.array, List[str], Any], None, None]:
+        if len(self.preloaded_datas) > 0:
+            if self.dataset.mode == DataSetMode.TRAIN:
+                # train mode wont generate parameters
+                if self.generate_only_non_augmented:
+                    # preloaded params store the 'length' of the non augmented data
+                    for data, text, params in zip(self.preloaded_datas, self.preloaded_texts, self.preloaded_params):
+                        yield data, text, None
+                else:
+                    for data, text in zip(self.preloaded_datas, self.preloaded_texts):
+                        yield data, text, None
+            else:
+                # all other modes generate everything we got, but does not support data augmentation
+                for data, text, params in zip(self.preloaded_datas, self.preloaded_texts, self.preloaded_params):
+                    yield data, text, params
+
+        else:
+            data_aug_ratio = self.data_augmentation_amount if self.data_augmentation_amount < 1 else 1 - 1 / (self.data_augmentation_amount + 1)
+            for sample in self.dataset.samples():
+                line, text = self.dataset.load_single_sample(sample)
+                if not self.dataset.is_sample_valid(sample, line, text):
+                    if not self.skip_invalid_gt:
+                        print("ERROR: invalid sample {}".format(sample))
+                        continue
+
+                if self.data_processor:
+                    line, params = self.data_processor.apply([line], 1, False)[0]
+                else:
+                    params = None
+
+                if self.text_processor:
+                    text = self.text_processor.apply([text], 1, False)[0]
+
+                if self.data_augmenter and np.random.rand() <= data_aug_ratio:
+                    # data augmentation with given ratio
+                    line, text = self.data_augmenter.augment_single(line, text)
+
+                yield line, text, params
+
+
+
+
+

--- a/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
@@ -69,11 +69,14 @@ class PageXMLDataset(DataSet):
         box[rr - offset[0], cc - offset[1]] = pageimg[rr, cc]
         return box
 
-    def _load_sample(self, sample):
+    def _load_sample(self, sample, text_only):
         image_path = sample["imgfile"]
         text = sample["text"]
-
         img = None
+
+        if text_only:
+            return img, text
+
         if self.mode == DataSetMode.PREDICT or self.mode == DataSetMode.TRAIN:
             img = np.array(Image.open(image_path))
 

--- a/calamari_ocr/ocr/predictor.py
+++ b/calamari_ocr/ocr/predictor.py
@@ -8,6 +8,7 @@ from google.protobuf import json_format
 
 from calamari_ocr.ocr.text_processing import text_processor_from_proto
 from calamari_ocr.ocr.data_processing import data_processor_from_proto
+from calamari_ocr.ocr.datasets import InputDataset, RawInputDataset, DataSetMode
 from calamari_ocr.ocr import Codec, Checkpoint
 from calamari_ocr.ocr.backends import create_backend_from_proto
 from calamari_ocr.proto import CheckpointParams
@@ -15,7 +16,7 @@ from calamari_ocr.utils.output_to_input_transformer import OutputToInputTransfor
 
 
 class PredictionResult:
-    def __init__(self, prediction, codec, text_postproc, out_to_in_trans, data_proc_params):
+    def __init__(self, prediction, codec, text_postproc, out_to_in_trans, data_proc_params, ground_truth=None):
         """ The output of a networks prediction (PredictionProto) with additional information
 
         It stores all required information for decoding (`codec`) and interpreting the output.
@@ -38,6 +39,7 @@ class PredictionResult:
         self.prediction.sentence = self.sentence
         self.out_to_in_trans = out_to_in_trans
         self.data_proc_params = data_proc_params
+        self.ground_truth = ground_truth
 
         self.prediction.avg_char_probability = 0
 
@@ -56,7 +58,9 @@ class PredictionResult:
 class Predictor:
     def __init__(self, checkpoint=None, text_postproc=None, data_preproc=None, codec=None, network=None,
                  batch_size=1, processes=1,
-                 auto_update_checkpoints=True):
+                 auto_update_checkpoints=True,
+                 with_gt=False,
+                 ):
         """ Predicting a dataset based on a trained model
 
         Parameters
@@ -80,11 +84,14 @@ class Predictor:
             The number of processes to use for prediction
         auto_update_checkpoints : bool, optional
             Update old models automatically (this will change the checkpoint files)
+        with_gt : bool, optional
+            The prediction will also output the ground truth if available else None
         """
         self.network = network
         self.checkpoint = checkpoint
         self.processes = processes
         self.auto_update_checkpoints = auto_update_checkpoints
+        self.with_gt = with_gt
 
         if checkpoint:
             if network:
@@ -93,13 +100,18 @@ class Predictor:
             ckpt = Checkpoint(checkpoint, auto_update=self.auto_update_checkpoints)
             checkpoint_params = ckpt.checkpoint
             self.model_params = checkpoint_params.model
+            self.codec = codec if codec else Codec(self.model_params.codec.charset)
 
             self.network_params = self.model_params.network
             backend = create_backend_from_proto(self.network_params, restore=self.checkpoint, processes=processes)
-            self.network = backend.create_net(restore=self.checkpoint, weights=None, graph_type="predict", batch_size=batch_size)
             self.text_postproc = text_postproc if text_postproc else text_processor_from_proto(self.model_params.text_postprocessor, "post")
             self.data_preproc = data_preproc if data_preproc else data_processor_from_proto(self.model_params.data_preprocessor)
+            self.network = backend.create_net(
+                dataset=None,
+                codec=self.codec,
+                restore=self.checkpoint, weights=None, graph_type="predict", batch_size=batch_size)
         elif network:
+            self.codec = codec
             self.model_params = None
             self.network_params = network.network_proto
             self.text_postproc = text_postproc
@@ -109,10 +121,9 @@ class Predictor:
         else:
             raise Exception("Either a checkpoint or a existing backend must be provided")
 
-        self.codec = codec if codec else Codec(self.model_params.codec.charset)
         self.out_to_in_trans = OutputToInputTransformer(self.data_preproc, self.network)
 
-    def predict_dataset(self, dataset, progress_bar=True):
+    def predict_dataset(self, dataset, progress_bar=True, apply_preproc=True):
         """ Predict a complete dataset
 
         Parameters
@@ -129,16 +140,13 @@ class Predictor:
         dict
             Dataset entry of the prediction result
         """
-        dataset.load_samples(processes=1, progress_bar=progress_bar)
-        datas = dataset.prediction_samples()
-        data_params = zip(datas, [None] * len(datas))
-
-        prediction_results = self.predict_raw(data_params, progress_bar)
+        input_dataset = InputDataset(dataset, self.data_preproc if apply_preproc else None, self.text_postproc if apply_preproc else None)
+        prediction_results = self.predict_input_dataset(input_dataset, progress_bar)
 
         for prediction, sample in zip(prediction_results, dataset.samples()):
             yield prediction, sample
 
-    def predict_raw(self, data_params, progress_bar=True, apply_preproc=True):
+    def predict_input_dataset(self, input_dataset: InputDataset, progress_bar=True):
         """ Predict raw data
         Parameters
         ----------
@@ -154,21 +162,18 @@ class Predictor:
             A single PredictionResult
         """
 
-        datas, params = zip(*data_params)
-
-        # preprocessing step
-        if apply_preproc:
-            datas, params = zip(*self.data_preproc.apply(datas, processes=self.processes, progress_bar=progress_bar))
-
-        self.network.set_data(datas)
+        self.network.set_input_dataset(input_dataset, self.codec)
+        self.network.prepare(uninitialized_variables_only=True)
 
         if progress_bar:
-            out = tqdm(self.network.prediction_step(), desc="Prediction", total=len(datas))
+            out = tqdm(self.network.prediction_step(), desc="Prediction", total=len(input_dataset))
         else:
             out = self.network.prediction_step()
 
-        for p, param in zip(out, params):
-            yield PredictionResult(p, codec=self.codec, text_postproc=self.text_postproc, out_to_in_trans=self.out_to_in_trans, data_proc_params=param)
+        for p in out:
+            yield PredictionResult(p.decoded, codec=self.codec, text_postproc=self.text_postproc,
+                                   out_to_in_trans=self.out_to_in_trans, data_proc_params=p.params,
+                                   ground_truth=p.ground_truth)
 
 
 class MultiPredictor:
@@ -209,7 +214,9 @@ class MultiPredictor:
 
         # preprocessing step (if all share the same preprocessor)
         if self.same_preproc:
-            datas = self.predictors[0].data_preproc.apply(datas, processes=self.processes, progress_bar=progress_bar)
+            data_params = self.predictors[0].data_preproc.apply(datas, processes=self.processes, progress_bar=progress_bar)
+        else:
+            raise Exception('Different preprocessors are currently not allowed during prediction')
 
         def progress_bar_wrapper(l):
             if progress_bar:
@@ -219,12 +226,20 @@ class MultiPredictor:
                 return l
 
         for data_idx in progress_bar_wrapper(range(0, len(datas), self.batch_size)):
-            batch_data = datas[data_idx:data_idx+self.batch_size]
+            batch_data_params = data_params[data_idx:data_idx+self.batch_size]
             samples = dataset.samples()[data_idx:data_idx+self.batch_size]
+            raw_dataset = [
+                RawInputDataset(DataSetMode.PREDICT,
+                                [img for img, _ in batch_data_params],
+                                [None] * len(batch_data_params),
+                                [p for _, p in batch_data_params],
+                                None if self.same_preproc else p.data_preproc,
+                                None if self.same_preproc else p.text_postproc,
+                                ) for p in self.predictors]
 
-            # predict_raw returns list of [pred (batch_size), time]
-            prediction = [predictor.predict_raw(batch_data, progress_bar=False, apply_preproc=not self.same_preproc)
-                          for predictor in self.predictors]
+            # predict_raw returns list of prediction objects
+            prediction = [predictor.predict_input_dataset(ds, progress_bar=False)
+                          for ds, predictor in zip(raw_dataset, self.predictors)]
 
             for result, sample in zip(zip(*prediction), samples):
                 yield result, sample

--- a/calamari_ocr/ocr/trainer.py
+++ b/calamari_ocr/ocr/trainer.py
@@ -1,6 +1,7 @@
 from calamari_ocr.ocr.text_processing import text_processor_from_proto
 from calamari_ocr.ocr.data_processing import data_processor_from_proto
 from calamari_ocr.ocr import Codec, Checkpoint
+from calamari_ocr.ocr.augmentation import DataAugmenter
 from calamari_ocr.ocr.backends import create_backend_from_proto
 import time
 import os
@@ -14,6 +15,8 @@ from calamari_ocr.proto import CheckpointParams
 
 from google.protobuf import json_format
 
+from .datasets import InputDataset
+
 
 class Trainer:
     def __init__(self, checkpoint_params,
@@ -22,12 +25,14 @@ class Trainer:
                  txt_preproc=None,
                  txt_postproc=None,
                  data_preproc=None,
-                 data_augmenter=None,
+                 data_augmenter: DataAugmenter = None,
                  n_augmentations=0,
                  weights=None,
                  codec=None,
                  codec_whitelist=[],
                  auto_update_checkpoints=True,
+                 preload_training=False,
+                 preload_validation=False,
                  ):
         """Train a DNN using given preprocessing, weights, and data
 
@@ -70,10 +75,6 @@ class Trainer:
             List of characters to be kept when the loaded `weights` have a different codec than the new one.
         """
         self.checkpoint_params = checkpoint_params
-        self.dataset = dataset
-        self.validation_dataset = validation_dataset
-        self.data_augmenter = data_augmenter
-        self.n_augmentations = n_augmentations
         self.txt_preproc = txt_preproc if txt_preproc else text_processor_from_proto(checkpoint_params.model.text_preprocessor, "pre")
         self.txt_postproc = txt_postproc if txt_postproc else text_processor_from_proto(checkpoint_params.model.text_postprocessor, "post")
         self.data_preproc = data_preproc if data_preproc else data_processor_from_proto(checkpoint_params.model.data_preprocessor)
@@ -81,8 +82,18 @@ class Trainer:
         self.codec = codec
         self.codec_whitelist = codec_whitelist
         self.auto_update_checkpoints = auto_update_checkpoints
+        self.dataset = InputDataset(dataset, self.data_preproc, self.txt_preproc, data_augmenter, n_augmentations)
+        self.validation_dataset = InputDataset(validation_dataset, self.data_preproc, self.txt_preproc) if validation_dataset else None
+        self.preload_training = preload_training
+        self.preload_validation = preload_validation
 
-    def train(self, progress_bar=False):
+        if len(self.dataset) == 0:
+            raise Exception("Dataset is empty.")
+
+        if self.validation_dataset and len(self.validation_dataset) == 0:
+            raise Exception("Validation dataset is empty. Provide valid validation data for early stopping.")
+
+    def train(self, auto_compute_codec=False, progress_bar=False):
         """ Launch the training
 
         Parameters
@@ -95,40 +106,23 @@ class Trainer:
 
         train_start_time = time.time() + self.checkpoint_params.total_time
 
-        self.dataset.load_samples(processes=1, progress_bar=progress_bar)
-        datas, txts = self.dataset.train_samples(skip_empty=checkpoint_params.skip_invalid_gt)
-        if len(datas) == 0:
-            raise Exception("Empty dataset is not allowed. Check if the data is at the correct location")
+        # load training dataset
+        if self.preload_training:
+            self.dataset.preload(processes=checkpoint_params.processes, progress_bar=progress_bar)
 
-        if self.validation_dataset:
-            self.validation_dataset.load_samples(processes=1, progress_bar=progress_bar)
-            validation_datas, validation_txts = self.validation_dataset.train_samples(skip_empty=checkpoint_params.skip_invalid_gt)
-            if len(validation_datas) == 0:
-                raise Exception("Validation dataset is empty. Provide valid validation data for early stopping.")
-        else:
-            validation_datas, validation_txts = [], []
-
-        # preprocessing steps
-        texts = self.txt_preproc.apply(txts, processes=checkpoint_params.processes, progress_bar=progress_bar)
-        datas, params = [list(a) for a in zip(*self.data_preproc.apply(datas, processes=checkpoint_params.processes, progress_bar=progress_bar))]
-        validation_txts = self.txt_preproc.apply(validation_txts, processes=checkpoint_params.processes, progress_bar=progress_bar)
-        validation_data_params = self.data_preproc.apply(validation_datas, processes=checkpoint_params.processes, progress_bar=progress_bar)
+        # load validation dataset
+        if self.validation_dataset and self.preload_validation:
+            self.validation_dataset.preload(processes=checkpoint_params.processes, progress_bar=progress_bar)
 
         # compute the codec
-        codec = self.codec if self.codec else Codec.from_texts(texts, whitelist=self.codec_whitelist)
-
-        # store original data in case data augmentation is used with a second step
-        original_texts = texts
-        original_datas = datas
-
-        # data augmentation on preprocessed data
-        if self.data_augmenter:
-            datas, texts = self.data_augmenter.augment_datas(datas, texts, n_augmentations=self.n_augmentations,
-                                                             processes=checkpoint_params.processes, progress_bar=progress_bar)
-
-            # TODO: validation data augmentation
-            # validation_datas, validation_txts = self.data_augmenter.augment_datas(validation_datas, validation_txts, n_augmentations=0,
-            #                                                  processes=checkpoint_params.processes, progress_bar=progress_bar)
+        if self.codec:
+            codec = self.codec
+        else:
+            if len(self.codec_whitelist) == 0 or auto_compute_codec:
+                codec = Codec.from_input_dataset([self.dataset, self.validation_dataset],
+                                                 whitelist=self.codec_whitelist, progress_bar=True)
+            else:
+                codec = Codec.from_texts([], whitelist=self.codec_whitelist)
 
         # create backend
         network_params = checkpoint_params.model.network
@@ -162,16 +156,11 @@ class Trainer:
         checkpoint_params.model.codec.charset[:] = codec.charset
         print("CODEC: {}".format(codec.charset))
 
-        # compute the labels with (new/current) codec
-        labels = [codec.encode(txt) for txt in texts]
-
         backend = create_backend_from_proto(network_params,
                                             weights=self.weights,
                                             )
-        train_net = backend.create_net(restore=None, weights=self.weights, graph_type="train", batch_size=checkpoint_params.batch_size)
-        test_net = backend.create_net(restore=None, weights=self.weights, graph_type="test", batch_size=checkpoint_params.batch_size)
-        train_net.set_data(datas, labels)
-        test_net.set_data(validation_datas, validation_txts)
+        train_net = backend.create_net(self.dataset, codec, restore=None, weights=self.weights, graph_type="train", batch_size=checkpoint_params.batch_size)
+        test_net = backend.create_net(self.validation_dataset, codec, restore=None, weights=self.weights, graph_type="test", batch_size=checkpoint_params.batch_size)
         if codec_changes:
             # only required on one net, since the other shares the same variables
             train_net.realign_model_labels(*codec_changes)
@@ -180,9 +169,9 @@ class Trainer:
         test_net.prepare()
 
         if checkpoint_params.current_stage == 0:
-            self._run_train(train_net, test_net, codec, validation_data_params, train_start_time, progress_bar)
+            self._run_train(train_net, test_net, codec, train_start_time, progress_bar)
 
-        if checkpoint_params.data_aug_retrain_on_original and self.data_augmenter and self.n_augmentations > 0:
+        if checkpoint_params.data_aug_retrain_on_original and self.dataset.data_augmenter and self.dataset.data_augmentation_amount > 0:
             print("Starting training on original data only")
             if checkpoint_params.current_stage == 0:
                 checkpoint_params.current_stage = 1
@@ -191,19 +180,18 @@ class Trainer:
                 checkpoint_params.early_stopping_best_cur_nbest = 0
                 checkpoint_params.early_stopping_best_accuracy = 0
 
-            train_net.set_data(original_datas, [codec.encode(txt) for txt in original_texts])
-            test_net.set_data(validation_datas, validation_txts)
+            self.dataset.generate_only_non_augmented = True  # this is the important line!
             train_net.prepare()
             test_net.prepare()
-            self._run_train(train_net, test_net, codec, validation_data_params, train_start_time, progress_bar)
+            self._run_train(train_net, test_net, codec, train_start_time, progress_bar)
 
         train_net.prepare()  # reset the state
         test_net.prepare()   # to prevent blocking of tensorflow on shutdown
 
-    def _run_train(self, train_net, test_net, codec, validation_data_params, train_start_time, progress_bar):
+    def _run_train(self, train_net, test_net, codec, train_start_time, progress_bar):
         checkpoint_params = self.checkpoint_params
-        validation_txts = test_net.raw_labels
-        iters_per_epoch = max(1, int(len(train_net.raw_images) / checkpoint_params.batch_size))
+        validation_dataset = test_net.input_dataset
+        iters_per_epoch = max(1, int(len(train_net.input_dataset) / checkpoint_params.batch_size))
 
         loss_stats = RunningStatistics(checkpoint_params.stats_size, checkpoint_params.loss_stats)
         ler_stats = RunningStatistics(checkpoint_params.stats_size, checkpoint_params.ler_stats)
@@ -329,11 +317,11 @@ class Trainer:
                 if early_stopping_enabled and (iter + 1) % early_stopping_frequency == 0:
                     print("Checking early stopping model")
 
-                    out = early_stopping_predictor.predict_raw(validation_data_params,
-                                                               progress_bar=progress_bar, apply_preproc=False)
-                    pred_texts = [d.sentence for d in out]
-                    pred_texts = self.txt_preproc.apply(pred_texts, processes=checkpoint_params.processes, progress_bar=progress_bar)
-                    result = Evaluator.evaluate(gt_data=validation_txts, pred_data=pred_texts, progress_bar=progress_bar)
+                    out_gen = early_stopping_predictor.predict_input_dataset(validation_dataset,
+                                                                             progress_bar=progress_bar)
+                    result = Evaluator.evaluate_single_list(map(
+                        Evaluator.evaluate_single_args,
+                        map(lambda d: tuple(self.txt_preproc.apply([''.join(d.ground_truth), d.sentence])), out_gen)))
                     accuracy = 1 - result["avg_ler"]
 
                     if accuracy > early_stopping_best_accuracy:

--- a/calamari_ocr/utils/multiprocessing.py
+++ b/calamari_ocr/utils/multiprocessing.py
@@ -6,6 +6,16 @@ import subprocess
 from tqdm import tqdm
 
 
+def tqdm_wrapper(iterable, _sentinel=None, total=1, desc="", progress_bar=False):
+    if _sentinel:
+        raise Exception("You must call tqdm_wrapper by using parameter names to specify additional parameters.")
+
+    if not progress_bar:
+        return iterable
+    else:
+        return tqdm(iterable, total=total, desc=desc)
+
+
 def parallel_map(f, d, _sentinel=None, desc="", processes=1, progress_bar=False, use_thread_pool=False, max_tasks_per_child=None):
     if _sentinel:
         raise Exception("You must call parallel_map by using parameter names to specify additional parameters besides the default map(func, data).")


### PR DESCRIPTION
Support for loading training and validation data on the fly. Required params:
`--train_data_on_the_fly` and/or `--validation_data_on_the_fly`

To prevent the automatic codec computation (requires the loading of all text examples once) you can pass:
`--no_auto_compute_codec` and give a `--whitelist` with all the characters. Note that Calamari will crash atm if not all occurring characters are listed as soon as an unknown char is read.

On my setup this slows down the training by a factor of almost 10 due to loading from a HDD on a NFS. Possibly the difference will be lower when using a SSD.

The code is highly experimental, cause it is only roughly tested.