### PR TITLE
Fixed prediction using reset data instead of prepare

### DIFF
--- a/calamari_ocr/ocr/predictor.py
+++ b/calamari_ocr/ocr/predictor.py
@@ -163,7 +163,7 @@ class Predictor:
         """
 
         self.network.set_input_dataset(input_dataset, self.codec)
-        self.network.prepare(uninitialized_variables_only=True)
+        self.network.reset_data()
 
         if progress_bar:
             out = tqdm(self.network.prediction_step(), desc="Prediction", total=len(input_dataset))


### PR DESCRIPTION
Fixed bug, that the longer the prediction the longer it takes. Reason is that the graph got increased in size for each batch (called `prepare`). Now `reset_data` is called, but also fixed: `prepare` does not recreate initialize operations on each call (increasing graph size!).