### PR TITLE
Add --version flag to train and predict script

### DIFF
--- a/calamari_ocr/scripts/predict.py
+++ b/calamari_ocr/scripts/predict.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pkg_resources import get_distribution
 
 from bidi.algorithm import get_base_level
 
@@ -14,6 +15,7 @@ from calamari_ocr.proto import VoterParams, Predictions
 
 
 def run(args):
+
     # check if loading a json file
     if len(args.files) == 1 and args.files[0].endswith("json"):
         import json
@@ -113,6 +115,9 @@ def run(args):
 
 def main():
     parser = argparse.ArgumentParser()
+
+    _version = get_distribution('calamari_ocr').version
+    parser.add_argument('--version', action='version', version='%(prog)s v'+_version)
 
     parser.add_argument("--files", nargs="+", required=True, default=[],
                         help="List all image files that shall be processed")

--- a/calamari_ocr/scripts/train.py
+++ b/calamari_ocr/scripts/train.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pkg_resources import get_distribution
 
 from calamari_ocr.utils import glob_all, split_all_ext, keep_files_with_same_file_name
 from calamari_ocr.ocr.datasets import create_dataset, DataSetType, DataSetMode
@@ -11,8 +12,11 @@ from calamari_ocr.ocr.text_processing import \
 from calamari_ocr.proto import CheckpointParams, DataPreprocessorParams, TextProcessorParams, \
     network_params_from_definition_string, NetworkParams
 
-
 def setup_train_args(parser, omit=[]):
+
+    _version = get_distribution('calamari_ocr').version
+    parser.add_argument('--version', action='version', version='%(prog)s v'+_version)
+
     if "files" not in omit:
         parser.add_argument("--files", nargs="+",
                             help="List all image files that shall be processed. Ground truth fils with the same "


### PR DESCRIPTION
We're experimenting with automated training workflows and one interesting variable is whether the engine was updated. Also, for provenance's sake it's important to know the version of the engine a model was trained with. 