### PR TITLE
require scikit-image>=0.15.0

### DIFF
--- a/environment_dev_cpu.yml
+++ b/environment_dev_cpu.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.7
   - lxml
-  - scikit-image
+  - scikit-image>=0.15.0
   - tqdm
   - python-bidi
   - edit_distance

--- a/environment_dev_gpu.yml
+++ b/environment_dev_gpu.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.7
   - lxml
-  - scikit-image
+  - scikit-image>=0.15.0
   - tqdm
   - python-bidi
   - edit_distance

--- a/environment_master_cpu.yml
+++ b/environment_master_cpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.6
   - tensorflow
   - lxml
-  - scikit-image
+  - scikit-image>=0.15.0
   - tqdm
   - python-bidi
   - edit_distance

--- a/environment_master_gpu.yml
+++ b/environment_master_gpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.6
   - tensorflow-gpu
   - lxml
-  - scikit-image
+  - scikit-image>=0.15.0
   - tqdm
   - python-bidi
   - edit_distance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 tqdm
-scikit-image
+scikit-image>=0.15.0
 python-bidi
 edit_distance
 xlsxwriter


### PR DESCRIPTION
With scikit-image 0.14.1 I got

```
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/calamari_ocr/ocr/__init__.py", line 2, in <module>
    from calamari_ocr.ocr.codec import Codec
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/calamari_ocr/ocr/codec.py", line 2, in <module>
    from calamari_ocr.ocr.datasets import InputDataset
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/calamari_ocr/ocr/datasets/__init__.py", line 4, in <module>
    from .pagexml_dataset import PageXMLDataset
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/calamari_ocr/ocr/datasets/pagexml_dataset/__init__.py", line 1, in <module>
    from .dataset import PageXMLDataset
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py", line 6, in <module>
    from skimage.draw import polygon
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/skimage/__init__.py", line 167, in <module>
    from .util.dtype import (img_as_float32,
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/skimage/util/__init__.py", line 8, in <module>
    from .arraycrop import crop
  File "/data/monorepo/venv3.6/lib/python3.6/site-packages/skimage/util/arraycrop.py", line 8, in <module>
    from numpy.lib.arraypad import _validate_lengths
ImportError: cannot import name '_validate_lengths'

```