### PR TITLE
Update trainer.py

### DIFF
--- a/calamari_ocr/ocr/trainer.py
+++ b/calamari_ocr/ocr/trainer.py
@@ -88,7 +88,7 @@ class Trainer:
         self.auto_update_checkpoints = auto_update_checkpoints
         self.data_augmenter = data_augmenter
         self.n_augmentations = n_augmentations
-        self.dataset = StreamingInputDataset(dataset, self.data_preproc, self.txt_preproc, data_augmenter, n_augmentations)
+        self.dataset = StreamingInputDataset(dataset, self.data_preproc, self.txt_preproc, data_augmenter, n_augmentations, True, self.checkpoint_params.processes)
         self.validation_dataset = StreamingInputDataset(validation_dataset, self.data_preproc, self.txt_preproc) if validation_dataset else None
         self.preload_training = preload_training
         self.preload_validation = preload_validation


### PR DESCRIPTION
num_threads was ignored in the data preloading operation as part of calamari-train.
No matter num_threads nn, only 4 threads created during data preloading.
This fixes that issue.
For those who have processors with more than 4 cores, it can make a difference in pre loading times.

