### PR TITLE
PageXML: allow TextEquiv without index attribute

### DIFF
--- a/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
@@ -103,6 +103,10 @@ class PageXMLDatasetLoader:
         for textline in textlines:
             tequivs = textline.xpath('./ns:TextEquiv[@index="{}"]'.format(self.text_index),
                                 namespaces=ns)
+
+            if not tequivs:
+                tequivs = textline.xpath('./ns:TextEquiv', namespaces=ns)
+
             if len(tequivs) > 1:
                 logger.warning("PageXML is invalid: TextLine includes TextEquivs with non unique ids")
 


### PR DESCRIPTION
Works around a issue I had while working with some PageXML files that where edited and saved with Aletheia.

In my PageXML files `TextEquiv` does not have an index attribute, i.e. things look like this:

```
<TextLine><TextEquiv><Unicode>bla bla bla</Unicode></TextEquiv></TextLine>
```

Currently, Calamari will not find such `<TextEquiv>` tags. This PR adds a fallback for this case and just uses any `<TextEquiv>` tags without `index` attributes.