### PR TITLE
Only select TextEquivs without index when fallback mechanism is triggered

### DIFF
--- a/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
@@ -105,7 +105,7 @@ class PageXMLDatasetLoader:
                                 namespaces=ns)
 
             if not tequivs:
-                tequivs = textline.xpath('./ns:TextEquiv', namespaces=ns)
+                tequivs = textline.xpath('./ns:TextEquiv[not(@index)]', namespaces=ns)
 
             if len(tequivs) > 1:
                 logger.warning("PageXML is invalid: TextLine includes TextEquivs with non unique ids")


### PR DESCRIPTION
Changes the fallback behavior for selecting TextEquivs (which was initially introduced in f3514e9c8ac02b03fb3161965df6e029e476fe95) so that only TextEquivs __without an index__ attribute are selected when no TextEquiv with the selected `text_index` is found in a `TextLine` element.

This avoids training e.g. on _predicted text_ in cases where _ground truth_ in a TextEquiv is identified by `index="0"` and _predicted text_ by `index="1"`. With the current fallback behavior Calamari would treat the predicted text as training data when no GT-TextEquiv exists in the same Textline (when text_index is set to 0).
