### PR TITLE
Add word level element "prediction" for Page XML datasets

### DIFF
--- a/calamari_ocr/ocr/datasets/abbyy_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/abbyy_dataset/dataset.py
@@ -107,9 +107,9 @@ class AbbyyDataSet(DataSet):
                         "format": fo,
                     })
 
-    def store_text(self, sentence, sample, output_dir, extension):
+    def store_text(self, prediction, sample, output_dir, extension):
         # an Abbyy dataset stores the prediction in one XML file
-        sample["format"].text = sentence
+        sample["format"].text = prediction.sentence
 
     def store(self, extension):
         for page in tqdm(self.book.pages, desc="Writing Abbyy files", total=len(self.book.pages)):

--- a/calamari_ocr/ocr/datasets/dataset.py
+++ b/calamari_ocr/ocr/datasets/dataset.py
@@ -165,10 +165,10 @@ class DataSet(ABC):
 
         return True
 
-    def store_text(self, sentence, sample, output_dir, extension):
+    def store_text(self, prediction, sample, output_dir, extension):
         output_dir = output_dir if output_dir else os.path.dirname(sample['image_path'])
         with codecs.open(os.path.join(output_dir, sample['id'] + extension), 'w', 'utf-8') as f:
-            f.write(sentence)
+            f.write(prediction.sentence)
 
     def store_extended_prediction(self, data, sample, output_dir, extension):
         if extension == "pred":

--- a/calamari_ocr/ocr/datasets/hdf5_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/hdf5_dataset/dataset.py
@@ -62,9 +62,9 @@ class Hdf5DataSet(DataSet):
                     "filename": filename,
                 })
 
-    def store_text(self, sentence, sample, output_dir, extension):
+    def store_text(self, prediction, sample, output_dir, extension):
         codec = self.prediction[sample['filename']]['codec']
-        self.prediction[sample['filename']]['transcripts'].append(list(map(codec.index, sentence)))
+        self.prediction[sample['filename']]['transcripts'].append(list(map(codec.index, prediction.sentence)))
 
     def store(self, extension):
         for filename, data in self.prediction.items():

--- a/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
@@ -280,6 +280,9 @@ class PageXMLDataset(DataSet):
         positions = remove_leading_spaces(positions)
         positions = remove_trailing_spaces(positions)
 
+        if not positions:
+            return []
+
         words = [{"char": positions[0][0], "min_x": positions[0][1], "max_x": positions[0][2],
                   "min_y": min_y, "max_y": max_y}]
         new_word = False
@@ -315,7 +318,7 @@ class PageXMLDataset(DataSet):
 
         words = self.get_words(prediction, sample)
 
-        if textequivelem is not None:
+        if len(textequivelem) and words:
             for index, word in enumerate(words, 1):
                 word_elem = etree.Element("{%s}Word" % ns["ns"], nsmap=ns, id=f"{line_id}_w{str(index).zfill(3)}")
                 textequivelem.addprevious(word_elem)

--- a/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import numpy as np
 from PIL import Image
@@ -190,7 +191,6 @@ class PageXMLDataset(DataSet):
                  ):
 
         """ Create a dataset from a Path as String
-
         Parameters
          ----------
         files : [], required
@@ -215,6 +215,7 @@ class PageXMLDataset(DataSet):
         self.args = args
 
         self.text_index = args.get('text_index', 0)
+        self.word_level = args.get('word_level', 0)
 
         self._non_existing_as_empty = non_existing_as_empty
         if len(xmlfiles) == 0:
@@ -254,12 +255,73 @@ class PageXMLDataset(DataSet):
         box[rr - offset[0], cc - offset[1]] = pageimg[rr, cc]
         return box
 
+    @staticmethod
+    def get_words(prediction, sample):
+        def remove_leading_spaces(_positions):
+            return list(itertools.dropwhile(lambda p: p[0][0] == " ", _positions))
+
+        def remove_trailing_spaces(_positions):
+            return list(reversed(remove_leading_spaces(reversed(_positions))))
+
+        x_coords, y_coords = map(list, zip(*[coord.split(",") for coord in sample['coords'].split()]))
+        x, y = [int(x) for x in x_coords], [int(y) for y in y_coords]
+        min_x, max_x, min_y, max_y = min(x), max(x), min(y), max(y)
+
+        positions = [(pos.chars[0].char, pos.global_start + min_x, pos.global_end + min_x) for pos in
+                     prediction.positions]
+        positions = remove_leading_spaces(positions)
+        positions = remove_trailing_spaces(positions)
+
+        words = [{"char": positions[0][0], "min_x": positions[0][1], "max_x": positions[0][2],
+                  "min_y": min_y, "max_y": max_y}]
+        new_word = False
+
+        for pos, entry in enumerate(positions[1:]):
+            if entry[0] == " ":
+                words.append({"char": entry[0], "min_x": entry[1], "max_x": entry[2], "min_y": min_y, "max_y": max_y})
+                new_word = True
+                continue
+            if new_word:
+                words.append({"char": entry[0], "min_x": entry[1], "max_x": entry[2], "min_y": min_y, "max_y": max_y})
+                new_word = False
+            else:
+                words[-1]["char"] += entry[0]
+                words[-1]["max_x"] = entry[2]
+
+        return words
+
+    def store_words(self, prediction, sample):
+        ns = sample['ns']
+        line = sample['xml_element']
+
+        line_id = line.attrib["id"]
+        textequivelem = line.find("./ns:TextEquiv", namespaces=ns)
+
+        words = self.get_words(prediction, sample)
+
+        if textequivelem is not None:
+            for index, word in enumerate(words, 1):
+                word_elem = etree.Element("Word", id=f"{line_id}_w{str(index).zfill(3)}")
+                textequivelem.addprevious(word_elem)
+
+                _points = f'{word["min_x"]},{word["max_y"]} {word["max_x"]},{word["max_y"]} {word["max_x"]},{word["min_y"]} {word["min_x"]},{word["min_y"]}'
+                etree.SubElement(word_elem, "Coords", attrib={"points": _points})
+
+                word_textequivxml = etree.SubElement(word_elem, "TextEquiv", attrib={"index": str(self.text_index)})
+
+                w_xml = etree.SubElement(word_textequivxml, "Unicode")
+                w_xml.text = word["char"]
+
     def prepare_store(self):
         self._last_page_id = None
 
-    def store_text(self, sentence, sample, output_dir, extension):
+    def store_text(self, prediction, sample, output_dir, extension):
         ns = sample['ns']
         line = sample['xml_element']
+
+        for word_elem in line.findall(".//ns:Word", namespaces=ns):
+            line.remove(word_elem)
+
         textequivxml = line.find('./ns:TextEquiv[@index="{}"]'.format(self.text_index),
                                     namespaces=ns)
         if textequivxml is None:
@@ -269,7 +331,10 @@ class PageXMLDataset(DataSet):
         if u_xml is None:
             u_xml = etree.SubElement(textequivxml, "Unicode")
 
-        u_xml.text = sentence
+        u_xml.text = prediction.sentence
+
+        if self.word_level and prediction.positions:
+            self.store_words(prediction, sample)
 
         # check if page can be stored, this requires that (standard in prediction) the pages are passed sequentially
         if self._last_page_id != sample['page_id']:

--- a/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
@@ -301,7 +301,7 @@ class PageXMLDataset(DataSet):
 
         if textequivelem is not None:
             for index, word in enumerate(words, 1):
-                word_elem = etree.Element("Word", id=f"{line_id}_w{str(index).zfill(3)}")
+                word_elem = etree.Element("{%s}Word" % ns["ns"], nsmap=ns, id=f"{line_id}_w{str(index).zfill(3)}")
                 textequivelem.addprevious(word_elem)
 
                 _points = f'{word["min_x"]},{word["max_y"]} {word["max_x"]},{word["max_y"]} {word["max_x"]},{word["min_y"]} {word["min_x"]},{word["min_y"]}'

--- a/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
+++ b/calamari_ocr/ocr/datasets/pagexml_dataset/dataset.py
@@ -276,7 +276,7 @@ class PageXMLDataset(DataSet):
                   "min_y": min_y, "max_y": max_y}]
         new_word = False
 
-        for pos, entry in enumerate(positions[1:]):
+        for entry in positions[1:]:
             if entry[0] == " ":
                 words.append({"char": entry[0], "min_x": entry[1], "max_x": entry[2], "min_y": min_y, "max_y": max_y})
                 new_word = True

--- a/calamari_ocr/scripts/predict.py
+++ b/calamari_ocr/scripts/predict.py
@@ -80,6 +80,7 @@ def run(args):
         remove_invalid=True,
         args={
             'text_index': args.pagexml_text_index,
+            'word_level': args.pagexml_word_level,
             'pad': args.dataset_pad,
         },
     )
@@ -115,7 +116,7 @@ def run(args):
 
         output_dir = args.output_dir
 
-        dataset.store_text(sentence, sample, output_dir=output_dir, extension=args.extension)
+        dataset.store_text(prediction, sample, output_dir=output_dir, extension=args.extension)
 
         if args.extended_prediction_data:
             ps = Predictions()
@@ -187,6 +188,7 @@ def main():
     # dataset extra args
     parser.add_argument("--dataset_pad", default=None, nargs='+', type=int)
     parser.add_argument("--pagexml_text_index", default=1)
+    parser.add_argument("--pagexml_word_level", action="store_true", help="Save word elements in PAGE XML.")
 
     args = parser.parse_args()
 

--- a/calamari_ocr/scripts/predict.py
+++ b/calamari_ocr/scripts/predict.py
@@ -81,6 +81,7 @@ def run(args):
         args={
             'text_index': args.pagexml_text_index,
             'word_level': args.pagexml_word_level,
+            'word_boundary': args.pagexml_word_boundary,
             'pad': args.dataset_pad,
         },
     )
@@ -189,6 +190,7 @@ def main():
     parser.add_argument("--dataset_pad", default=None, nargs='+', type=int)
     parser.add_argument("--pagexml_text_index", default=1)
     parser.add_argument("--pagexml_word_level", action="store_true", help="Save word elements in PAGE XML.")
+    parser.add_argument("--pagexml_word_boundary", default="unicode", choices=["unicode", "whitespace"])
 
     args = parser.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ lxml
 h5py
 protobuf
 prettytable
-tensorflow>=2.0
+tensorflow


### PR DESCRIPTION
Adds the flag `--pagexml_word_level` to `predict.py` which enables the generation of `Word` elements when predicting on Page XML datasets.

"Words" are generated from the `positions` returned by the prediction.
All character sequences separated by spaces are classified as a "word". 
All (non-leading/non-trailing) spaces are also classified as "words" and saved as `Word` elements. 
As far as I know the PAGE XML schema doesn't have any clear decisions on whether whitespaces should be declared in `Word` elements, so this is probably a very subjective decision.
