### PR TITLE
changed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The current release can be accessed [here](https://github.com/Calamari-OCR/calam
 Calamari is available on [pypi](https://pypi.org/project/calamari-ocr):
 
 ```shell
-pip install calamari_ocr
+pip install calamari-ocr
 ```
 
 Read the [docs](https://calamari-ocr.readthedocs.io) for further instructions.


### PR DESCRIPTION
s/`calamari_ocr`/`calamari-ocr`/

Typo, I guess. `calamari_ocr` downloads calamari v1.0.5.