### PR TITLE
Fix for auto rotation of PageXML lines (not used in CLI)

### DIFF
--- a/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
+++ b/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
@@ -293,7 +293,7 @@ class PageXMLReader(CalamariDataGenerator[PageXML]):
         minX, minY = (0, 0)
 
         # calculate angle if needed
-        if angle is None: 
+        if angle is None:
             if max_auto_angle > 0:
                 angle = mbr[2] - 90 if mbr[2] > 45 else mbr[2]
                 if abs(angle) > max_auto_angle:

--- a/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
+++ b/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
@@ -295,6 +295,7 @@ class PageXMLReader(CalamariDataGenerator[PageXML]):
         # calculate angle if needed
         if angle is None:
             if max_auto_angle > 0:
+                mbr = cv.minAreaRect(coords)
                 angle = mbr[2] - 90 if mbr[2] > 45 else mbr[2]
                 if abs(angle) > max_auto_angle:
                     angle = 0

--- a/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
+++ b/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
@@ -256,6 +256,7 @@ class PageXMLReader(CalamariDataGenerator[PageXML]):
         coordstring: str,
         mode: CutMode,
         angle=0,
+        max_auto_angle=0,
         cval=None,
         scale=1,
     ):
@@ -270,7 +271,9 @@ class PageXMLReader(CalamariDataGenerator[PageXML]):
             CutMode.MBR : cut minimum bounding rectangle around coordinates
         angle :
             float : rotate angle in clockwise direction
-            None : calculate angle from minimum bounding rectangle
+            None : guess angle from minimum bounding rectangle
+        max_auto_angle :
+            float : if angle is None, try to guess angle up to boundary
         cval :
             colour : mask and fill empty regions with
             None : calculate via maximum pixel
@@ -290,9 +293,13 @@ class PageXMLReader(CalamariDataGenerator[PageXML]):
         minX, minY = (0, 0)
 
         # calculate angle if needed
-        if angle is None:
-            mbr = cv.minAreaRect(coords)
-            angle = mbr[2] if maxX <= maxY else mbr[2] - 90
+        if angle is None: 
+            if max_auto_angle > 0:
+                angle = mbr[2] - 90 if mbr[2] > 45 else mbr[2]
+                if abs(angle) > max_auto_angle:
+                    angle = 0
+            else:
+                angle = 0
 
         # set cval if needed
         if cval is None:


### PR DESCRIPTION
The way opencv returns rotation angles is quite opaque. I need to set an maximum for the angle to prevent the lines from spinning out of control.

This is only relevant for use as a library. I could have introduced a command line parameter for that behaviour, but since PageXMLDatasetLoader sets "orientation" to "0" when the attribute is not present in the PAGE XML, this would have meant some interdependency between command line parameters that would have been hard to understand for the user.