### PR TITLE
Prevent PageXML training on previous OCR results

### DIFF
--- a/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
+++ b/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
@@ -88,7 +88,7 @@ class PageXMLDatasetLoader:
             tequivs = textline.findall('./ns:TextEquiv[@index="{}"]'.format(self.text_index), namespaces=ns)
 
             if not tequivs:
-                tequivs = textline.findall("./ns:TextEquiv", namespaces=ns)
+                tequivs = [te for te in textline.findall("./ns:TextEquiv", namespaces=ns) if "index" not in te.attrib]
 
             if len(tequivs) > 1:
                 logger.warning("PageXML is invalid: TextLine includes TextEquivs with non unique ids")


### PR DESCRIPTION
I accidentally reverted my own fix that prevented the PAGE reader from including existing OCR text in the GT...