### PR TITLE
Fix final_preparation for already normalized data

### DIFF
--- a/calamari_ocr/ocr/dataset/imageprocessors/final_preparation.py
+++ b/calamari_ocr/ocr/dataset/imageprocessors/final_preparation.py
@@ -6,6 +6,7 @@ from paiargparse import pai_dataclass, pai_meta
 from tfaip.data.pipeline.processor.dataprocessor import DataProcessorParams
 
 from calamari_ocr.ocr.dataset.imageprocessors.data_preprocessor import ImageProcessor
+from calamari_ocr.utils.image import to_uint8
 
 
 @pai_dataclass(alt="FinalPreparation")
@@ -62,7 +63,7 @@ class FinalPreparation(ImageProcessor[FinalPreparationProcessorParams]):
                     ]
                 )
 
-        data = (data * 255).astype(np.uint8)
+        data = to_uint8(data)
 
         if channels == 1:
             data = np.squeeze(data, axis=-1)

--- a/calamari_ocr/ocr/dataset/imageprocessors/final_preparation.py
+++ b/calamari_ocr/ocr/dataset/imageprocessors/final_preparation.py
@@ -6,7 +6,7 @@ from paiargparse import pai_dataclass, pai_meta
 from tfaip.data.pipeline.processor.dataprocessor import DataProcessorParams
 
 from calamari_ocr.ocr.dataset.imageprocessors.data_preprocessor import ImageProcessor
-from calamari_ocr.utils.image import to_uint8
+from calamari_ocr.utils.image import to_uint8, to_float32
 
 
 @pai_dataclass(alt="FinalPreparation")
@@ -25,6 +25,8 @@ class FinalPreparationProcessorParams(DataProcessorParams):
 
 class FinalPreparation(ImageProcessor[FinalPreparationProcessorParams]):
     def _apply_single(self, data: np.ndarray, meta):
+        data = to_float32(data)
+
         if len(data.shape) != 3:
             data = np.expand_dims(data, axis=-1)  # add channels dimension
 

--- a/calamari_ocr/test/test_prediction.py
+++ b/calamari_ocr/test/test_prediction.py
@@ -157,16 +157,16 @@ class TestPrediction(unittest.TestCase):
     def test_empty_image_raw_prediction(self):
         predictor = create_single_model_predictor()
         images = [
-            np.zeros(shape=(0, 0)),
-            np.zeros(shape=(1, 0)),
-            np.zeros(shape=(0, 1)),
+            np.zeros(shape=(0, 0), dtype="float32"),
+            np.zeros(shape=(1, 0), dtype="int16"),
+            np.zeros(shape=(0, 1), dtype="uint8"),
         ]
         for result in predictor.predict_raw(images):
             print(result.outputs.sentence)
 
     def test_white_image_raw_prediction(self):
         predictor = create_single_model_predictor()
-        images = [np.zeros(shape=(200, 50))]
+        images = [np.zeros(shape=(200, 50), dtype="uint8")]
         for result in predictor.predict_raw(images):
             print(result.outputs.sentence)
 

--- a/calamari_ocr/utils/image.py
+++ b/calamari_ocr/utils/image.py
@@ -90,7 +90,7 @@ def to_uint8(data: np.ndarray) -> np.ndarray:
     elif data.dtype == bool:
         data = data.astype("uint8") * 255
     else:
-        raise Exception("unknown image type: {}".format(data.dtype))
+        raise Exception(f"Unknown image type: {data.dtype}")
 
     return data
 
@@ -105,14 +105,14 @@ def to_float32(data: np.ndarray) -> np.ndarray:
     elif data.dtype == np.dtype("int8"):
         data = (data.astype("int16") + 128).astype("float32") / 255
     elif data.dtype == np.dtype("uint16"):
-        data = data.astype("float32") / 256 / 255
+        data = data.astype("float32") / 65535
     elif data.dtype == np.dtype("int16"):
-        data = ((data.astype("float32") / 128) + 128) / 255
+        data = (data.astype("float32") + 32768) / 65535
     elif data.dtype in [np.dtype("f"), np.dtype("float32"), np.dtype("float64")]:
         data = data.astype("float32")
     elif data.dtype == bool:
         data = data.astype("float32")
     else:
-        raise Exception("unknown image type: {}".format(data.dtype))
+        raise Exception(f"Unknown image type: {data.dtype}")
 
     return data

--- a/calamari_ocr/utils/image.py
+++ b/calamari_ocr/utils/image.py
@@ -73,11 +73,9 @@ def load_image(image_path: str) -> np.ndarray:
 
 
 def to_uint8(data: np.ndarray) -> np.ndarray:
-    """
-    Read an image and returns it as uint8
-    The optional page number allows images from files containing multiple
-    images to be addressed.  All arrays are rescaled to
-    the range 0...255 (unsigned)
+    """Read an image and returns it as uint8
+
+    All arrays are rescaled to the range 0...255 (unsigned)
     """
     if data.dtype == np.dtype("uint8"):
         data = data
@@ -91,6 +89,29 @@ def to_uint8(data: np.ndarray) -> np.ndarray:
         data = (data * 255).astype("uint8")
     elif data.dtype == bool:
         data = data.astype("uint8") * 255
+    else:
+        raise Exception("unknown image type: {}".format(data.dtype))
+
+    return data
+
+
+def to_float32(data: np.ndarray) -> np.ndarray:
+    """Read an image and returns it as float32
+
+    All arrays are rescaled to the range 0...1
+    """
+    if data.dtype == np.dtype("uint8"):
+        data = data.astype("float32") / 255
+    elif data.dtype == np.dtype("int8"):
+        data = (data.astype("int16") + 128).astype("float32") / 255
+    elif data.dtype == np.dtype("uint16"):
+        data = data.astype("float32") / 256 / 255
+    elif data.dtype == np.dtype("int16"):
+        data = ((data.astype("float32") / 128) + 128) / 255
+    elif data.dtype in [np.dtype("f"), np.dtype("float32"), np.dtype("float64")]:
+        data = data.astype("float32")
+    elif data.dtype == bool:
+        data = data.astype("float32")
     else:
         raise Exception("unknown image type: {}".format(data.dtype))
 


### PR DESCRIPTION
When normalize=False is set, FinalPreparation must not multiply the data with 255. Otherwise it renders many line images unreadable.