### PR TITLE
hold TF and HDF5 dependencies at compatible versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-bidi
 edit_distance
 xlsxwriter
 lxml
-h5py
+h5py == 2.10
 protobuf
 prettytable
-tensorflow
+tensorflow >= 2.3.0, < 2.5.0


### PR DESCRIPTION
Current release of Tensorflow is 2.5, which drags in h5py 3.1, which is incompatible (see Calamari-OCR#223).

Fixes Calamari-OCR#223 and Calamari-OCR#179 for the current ecosystem and Calamari 1.

@ChWick please have a look!