### PR TITLE
Update setup to fix build warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.md
-licence-file = LICENSE
+description_file = README.md
+licence_file = LICENSE


### PR DESCRIPTION
This fixes these warnings:

    UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
    Usage of dash-separated 'licence-file' will not be supported in future versions. Please use the underscore name 'licence_file' instead

Signed-off-by: Stefan Weil <sw@weilnetz.de>