### PR TITLE
PageXML: Option to deal with existing words in the input file

### DIFF
--- a/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
+++ b/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
@@ -205,7 +205,7 @@ class PageXML(CalamariDataGeneratorParams):
         ),
     )
     delete_old_words: bool = field(
-        default=False,
+        default=True,
         metadata=pai_meta(
             help="If there are already words in the input, "
             + "delete them instead of writing the new ones alongside them."


### PR DESCRIPTION
This PR adds a new CLI parameter `--data.delete_old_words` to the `PageXMLReader`, which defaults to `True`. Prior to this PR, if an input PageXML file already had `Word` tags in it, Calamari would just kind of make a mess in the output...

With this option enabled, the words from the input will simply be removed from the element tree prior to writing the new ones. If disabled, the suffix `_old` will be appended to the IDs of all the existing words and their glyphs.

Previously, I tried to fix this issue by simply overwriting Word tags, which did not work out as smoothly. Remnants of this still exist in this PR, but due to the CLI parameter, this code works effectively the same as before. This can be reverted if needed.