### PR TITLE
calamari/1.0: Remove noisy/useless print around model.summary() call

### DIFF
--- a/calamari_ocr/ocr/backends/tensorflow_backend/tensorflow_model.py
+++ b/calamari_ocr/ocr/backends/tensorflow_backend/tensorflow_model.py
@@ -55,7 +55,7 @@ class TensorflowModel(ModelInterface):
         else:
             self.model = self.create_predictor()
 
-        print(self.model.summary())
+        self.model.summary()
 
     def create_predictor(self):
         return Model(inputs=[


### PR DESCRIPTION
In the TensorflowModel constructor, model.summary() is called to output a summary of the model created/loaded. TF's summary() prints itself, but returns None, so the print() around it always prints "None".

OCR-D just configured the amount of noi... console output wanted from TensorFlow, so while I don't get any output from summary() anymore, I do see this spurious "None", which we didn't notice before within the other messages by TF.

Only applies to Calamari 1.0, I think - but I didn't check 2.x very thoroughly.

API docs:
https://www.tensorflow.org/api_docs/python/tf/keras/Model#summary