### PR TITLE
provide predefined element_length_fn for pipeline.bucket_boundaries

### DIFF
--- a/calamari_ocr/ocr/dataset/data.py
+++ b/calamari_ocr/ocr/dataset/data.py
@@ -88,6 +88,7 @@ class Data(DataBase[DataParams]):
     def element_length_fn(self) -> Callable[[Dict[str, AnyTensor]], AnyTensor]:
         def img_len(x):
             return x["img_len"]
+
         return img_len
 
     def create_pipeline(

--- a/calamari_ocr/ocr/dataset/data.py
+++ b/calamari_ocr/ocr/dataset/data.py
@@ -1,8 +1,9 @@
 import logging
 import os
-from typing import Type, Optional
+from typing import Callable, Dict, Type, Optional
 
 import tensorflow as tf
+from tfaip.util.tftyping import AnyTensor
 from tfaip.data.data import DataBase
 from tfaip.data.databaseparams import DataPipelineParams
 from tfaip.data.pipeline.datapipeline import DataPipeline
@@ -83,6 +84,11 @@ class Data(DataBase[DataParams]):
             "gt": tf.TensorSpec([None], dtype=tf.int32),
             "gt_len": tf.TensorSpec([1], dtype=tf.int32),
         }
+
+    def element_length_fn(self) -> Callable[[Dict[str, AnyTensor]], AnyTensor]:
+        def img_len(x):
+            return x["img_len"]
+        return img_len
 
     def create_pipeline(
         self,

--- a/calamari_ocr/test/test_prediction.py
+++ b/calamari_ocr/test/test_prediction.py
@@ -212,6 +212,5 @@ class TestPrediction(unittest.TestCase):
         run(args)
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/calamari_ocr/test/test_prediction.py
+++ b/calamari_ocr/test/test_prediction.py
@@ -206,6 +206,12 @@ class TestPrediction(unittest.TestCase):
 
         predictor.benchmark_results.pretty_print()
 
+    def test_batch_bucketing(self):
+        args = predict_args()
+        args.predictor.pipeline.bucket_boundaries = [20, 50, 100, 200, 400, 800]
+        run(args)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
tfaip provides an option delegating to Tensorflow's [`tf.data.Dataset.bucket_by_sequence_length`](https://www.tensorflow.org/versions/r2.7/api_docs/python/tf/data/Dataset#bucket_by_sequence_length) (also known as _batch width or length bucketing_). This is really helpful for optimal use of memory resources on the GPU: as one tries to increase batch size for GPU utilization one must also be wary of OOM, and this is aggrevated by zero padding – so samples with largest length can spoil an entire batch's memory utilization. So batch bucketing groups batches into similar lengths.

Our CLIs even expose that (e.g. `--pipeline.bucket_boundaries 20 50 100 200 400 800 `), but:
1. the formula for bucket batch sizes was broken prior to tfaip 1.2.7, so one needed to _also_ calculate that (e.g. `--pipeline.bucket_batch_sizes 256 128 64 32 16 8`)  or basically observed the opposite effect
2. another ingredient was the `element_length_fn` parameter required by tfaip/TF – this is dependent on the data representation, and can only be formulated as code, so it must be done in Calamari itself

This PR addresses the final problem 2. (Note that on the API, it was already possible to achieve that, as https://github.com/OCR-D/ocrd_calamari/pull/118 showcases, but it would still be simpler if it was predefined.)

Following is a [plot](https://gist.github.com/bertsky/d992bb9c9ac231e29e615419d9ebb319) of measured GPU utilization for a typical `calamari-predict` on some 2500 lines **without** batch bucketing:
![calamari-predict-and-eval-tf2 13](https://github.com/user-attachments/assets/19532a86-e4ab-4060-8dc6-f891e8786ebf)


...and **with** batch bucketing (enabled by this PR):
![calamari-predict-and-eval-tf2 13-bb-N4](https://github.com/user-attachments/assets/6a514287-2011-47ec-ace5-505d7fccaba9)


So obviously GPU utilization gets a little less peaky.

But it's still peaky. (I have tried varying `num_processes`, `prefetch`, `use_shared_memory`, `dist_strategy` – but the effect is mostly negligible. So if anyone has ideas, please comment.)