### PR TITLE
calamari-predict-and-eval args

### DIFF
--- a/calamari_ocr/ocr/evaluator.py
+++ b/calamari_ocr/ocr/evaluator.py
@@ -257,5 +257,5 @@ class Evaluator:
         )
 
         res = Evaluator.evaluate_single_list(out, True)
-        res["ids"] = gt_ids
+        res["ids"] = list(gt_ids)
         return res

--- a/calamari_ocr/scripts/predict_and_eval.py
+++ b/calamari_ocr/scripts/predict_and_eval.py
@@ -35,6 +35,7 @@ class PredictAndEvalArgs:
         default_factory=FileDataParams,
         metadata=pai_meta(mode="flat", help="Input data", choices=DATA_GENERATOR_CHOICES),
     )
+    voter: VoterParams = field(default_factory=VoterParams)
     predictor: PredictorParams = field(
         default_factory=PredictorParams,
         metadata=pai_meta(mode="flat", help="Predictor data"),
@@ -71,10 +72,9 @@ def main(args: PredictAndEvalArgs):
 
     from calamari_ocr.ocr.predict.predictor import MultiPredictor
 
-    voter_params = VoterParams()
     predictor = MultiPredictor.from_paths(
         checkpoints=args.checkpoint,
-        voter_params=voter_params,
+        voter_params=args.voter,
         predictor_params=args.predictor,
     )
     do_prediction = predictor.predict(args.data)

--- a/calamari_ocr/scripts/predict_and_eval.py
+++ b/calamari_ocr/scripts/predict_and_eval.py
@@ -85,8 +85,8 @@ def main(args: PredictAndEvalArgs):
     for s in do_prediction:
         (result, prediction) = s.outputs
         sentence = prediction.sentence
-        if prediction.voter_predictions is not None and args.output_individual_voters:
-            for i, p in enumerate(prediction.voter_predictions):
+        if args.output_individual_voters:
+            for i, p in enumerate(result):
                 if i not in all_prediction_sentences:
                     all_prediction_sentences[i] = {}
                 all_prediction_sentences[i][s.meta["id"]] = p.sentence


### PR DESCRIPTION
This **adds** the `--voter` args (available in `calamari-predict`) to `calamari-predict-and-eval`.

Moreover, it **fixes** `--output_individual_voters` (relevant in combination with `--dump`): this assumed that voters are implemented as ensemble models, which they are not (anymore?). Now one needs to look up the individual predictor outputs in the `PredictionResult` lists contained in the second half of the `Sample.outputs` tuple.

Also contains a fix for `ids` contained in the `--dump` pickle: if serializing as a set, the order gets lost and thus useless.