### PR TITLE
fix word/glyph ID's, bound boxes and add output precision option

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: test-results
+        name: test-results-${{ strategy.job-index }}
         path: |
           .coverage
           coverage.xml

--- a/calamari_ocr/ocr/dataset/datareader/generated_line_dataset/line_generator.py
+++ b/calamari_ocr/ocr/dataset/datareader/generated_line_dataset/line_generator.py
@@ -55,7 +55,6 @@ class FontVariants:
         variants = [".ttf", "-regular.ttf", "-Regular.ttf", ".otf", "-regular.otf", "-Regular.otf"]
         self.font_name = base_font.split(".")[0]
 
-        
         for i, ext in enumerate(variants, start=1):
             try:
                 self.default_font = Font(ImageFont.truetype(self.font_name + ext, size=font_size))
@@ -66,7 +65,7 @@ class FontVariants:
                 if i < len(variants):
                     continue
                 raise e
-            
+
         def font_or_default(ttf):
             try:
                 return Font(ImageFont.truetype(ttf, size=font_size))

--- a/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
+++ b/calamari_ocr/ocr/dataset/datareader/pagexml/reader.py
@@ -35,13 +35,13 @@ class CutMode(IntEnum):
     BOX = 0
     POLYGON = 1
     MBR = 2
-    
+
 
 class OutputPrecision(IntEnum):
     LINES = 0
     WORDS = 1
     GLYPHS = 2
-    
+
 
 class PageXMLDatasetLoader:
     def __init__(
@@ -202,13 +202,12 @@ class PageXML(CalamariDataGeneratorParams):
         default=False, metadata=pai_meta(help="Write prediction confidences into the output.")
     )
     output_precision: OutputPrecision = field(
-        default=OutputPrecision.LINES,
-        metadata=(pai_meta(help="Specifies output precision."))
+        default=OutputPrecision.LINES, metadata=(pai_meta(help="Specifies output precision."))
     )
     max_glyph_alternatives: int = field(
         default=1,
         metadata=pai_meta(
-            help="When output_precision is set to GLYPH, determines the maximum amount of glyph alternatives to output."
+            help="When output_precision is set to GLYPHS, determines the maximum amount of glyph alternatives to output."
         ),
     )
     delete_old_words: bool = field(
@@ -545,7 +544,7 @@ class PageXMLReader(CalamariDataGenerator[PageXML]):
 
         line_id = line_xml.attrib.get("id")
         word_counter = 1
-        
+
         if line_baseline_xml is not None:
             # if there is a baseline element, insert after it
             insert_index = line_xml.index(line_baseline_xml) + 1
@@ -583,7 +582,7 @@ class PageXMLReader(CalamariDataGenerator[PageXML]):
             for glyph in word:
                 word_text += glyph.chars[0].char
                 word_confidence *= glyph.chars[0].probability
-                
+
                 if self.params.output_precision > 1:
                     self._store_glyph(glyph, word_id, word_xml, line_x, line_y, line_height, glyph_counter, ns)
                     glyph_counter += 1

--- a/calamari_ocr/ocr/dataset/imageprocessors/data_range_normalizer.py
+++ b/calamari_ocr/ocr/dataset/imageprocessors/data_range_normalizer.py
@@ -23,5 +23,8 @@ class DataRangeProcessor(ImageProcessor[DataRangeProcessorParams]):
 
         if data.ndim == 3:
             data = np.mean(data.astype("float32"), axis=2).astype(data.dtype)
-
+        meta["line_width"] = data.shape[1]
         return data
+
+    def local_to_global_pos(self, x, meta):
+        return min(max(x, 0), meta["line_width"])

--- a/calamari_ocr/ocr/dataset/imageprocessors/final_preparation.py
+++ b/calamari_ocr/ocr/dataset/imageprocessors/final_preparation.py
@@ -55,6 +55,7 @@ class FinalPreparation(ImageProcessor[FinalPreparationProcessorParams]):
                         np.full((self.params.pad, w, channels), self.params.pad_value),
                     ]
                 )
+                meta["padded_width"] = data.shape[0]
             else:
                 w = data.shape[0]
                 data = np.hstack(
@@ -64,6 +65,7 @@ class FinalPreparation(ImageProcessor[FinalPreparationProcessorParams]):
                         np.full((w, self.params.pad, channels), self.params.pad_value),
                     ]
                 )
+                meta["padded_width"] = data.shape[1]
 
         data = to_uint8(data)
 
@@ -72,8 +74,8 @@ class FinalPreparation(ImageProcessor[FinalPreparationProcessorParams]):
 
         return data
 
-    def local_to_global_pos(self, x, params):
+    def local_to_global_pos(self, x, meta):
         if self.params.pad > 0 and self.params.transpose:
-            return x - self.params.pad
+            return min(max(x - self.params.pad, 0), meta["padded_width"] - (2 * self.params.pad))
         else:
             return x

--- a/calamari_ocr/ocr/model/ctcdecoder/ctc_decoder.py
+++ b/calamari_ocr/ocr/model/ctcdecoder/ctc_decoder.py
@@ -116,7 +116,7 @@ class CTCDecoder(ABC):
             p = probabilities[start:end]
             p = np.max(p, axis=0)
 
-            pos = PredictionPosition(local_start=start, local_end=end - 1)
+            pos = PredictionPosition(local_start=start, local_end=end)
             pred.positions.append(pos)
 
             for label in reversed(sorted(range(len(p)), key=lambda v: p[v])):

--- a/calamari_ocr/ocr/model/ensemblemodel.py
+++ b/calamari_ocr/ocr/model/ensemblemodel.py
@@ -94,13 +94,13 @@ class EnsembleModel(ModelBase[EnsembleModelParams]):
     def _print_evaluate(self, sample: Sample, data, print_fn):
         targets, outputs = sample.targets, sample.outputs
         gt_sentence = targets["sentence"]
-        lr = "\u202A\u202B"
+        lr = "\u202a\u202b"
         s = ""
 
         pred_sentence = outputs.sentence
         cer = Levenshtein.distance(pred_sentence, gt_sentence) / len(gt_sentence)
         s += "\n  PRED (CER={:.2f}): '{}{}{}'".format(
-            cer, lr[bidi.get_base_level(pred_sentence)], pred_sentence, "\u202C"
-        ) + "\n  TRUE:            '{}{}{}'".format(lr[bidi.get_base_level(gt_sentence)], gt_sentence, "\u202C")
+            cer, lr[bidi.get_base_level(pred_sentence)], pred_sentence, "\u202c"
+        ) + "\n  TRUE:            '{}{}{}'".format(lr[bidi.get_base_level(gt_sentence)], gt_sentence, "\u202c")
 
         print_fn(s)

--- a/calamari_ocr/ocr/model/model.py
+++ b/calamari_ocr/ocr/model/model.py
@@ -69,10 +69,10 @@ class Model(ModelBase[ModelParams]):
         targets, outputs = sample.targets, sample.outputs
         pred_sentence = outputs.sentence
         gt_sentence = targets["sentence"]
-        lr = "\u202A\u202B"
+        lr = "\u202a\u202b"
         cer = Levenshtein.distance(pred_sentence, gt_sentence) / len(gt_sentence)
         print_fn(
             "\n  CER:  {}".format(cer)
-            + "\n  PRED: '{}{}{}'".format(lr[bidi.get_base_level(pred_sentence)], pred_sentence, "\u202C")
-            + "\n  TRUE: '{}{}{}'".format(lr[bidi.get_base_level(gt_sentence)], gt_sentence, "\u202C")
+            + "\n  PRED: '{}{}{}'".format(lr[bidi.get_base_level(pred_sentence)], pred_sentence, "\u202c")
+            + "\n  TRUE: '{}{}{}'".format(lr[bidi.get_base_level(gt_sentence)], gt_sentence, "\u202c")
         )

--- a/calamari_ocr/ocr/predict/params.py
+++ b/calamari_ocr/ocr/predict/params.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional
+from math import ceil
 import numpy as np
 
 import tfaip as tfaip
@@ -28,6 +29,8 @@ class PredictionPosition:
     local_end: int = 0
     global_start: int = 0
     global_end: int = 0
+    global_start_ext: int = 0
+    global_end_ext: int = 0
 
 
 @dataclass_json
@@ -92,14 +95,28 @@ class PredictionResult:
 
         self.prediction.avg_char_probability = 0
 
-        for p in self.prediction.positions:
+        for n, p in enumerate(self.prediction.positions):
             for c in p.chars:
                 c.char = codec.code2char[c.label]
 
             p.global_start = int(out_to_in_trans(p.local_start))
-            p.global_end = int(out_to_in_trans(p.local_end))
+            p.global_end = ceil(out_to_in_trans(p.local_end))
+
+            p_len = max(1, p.global_end - p.global_start)
+            if n == 0:
+                p.global_start_ext = max(0, (p.global_start - p_len) // 2)
+            else:
+                p.global_start_ext = (p.global_start + last_p.global_end) // 2
+                last_p.global_end_ext = p.global_start_ext
+
+            if n == len(self.prediction.positions) - 1:
+                line_len = out_to_in_trans(self.logits.shape[0])
+                p.global_end_ext = min(line_len, ceil((line_len + p.global_end + p_len) / 2))
+
             if len(p.chars) > 0:
                 self.prediction.avg_char_probability += p.chars[0].probability
+
+            last_p = p
 
         self.prediction.avg_char_probability /= (
             len(self.prediction.positions) if len(self.prediction.positions) > 0 else 1

--- a/calamari_ocr/ocr/predict/params.py
+++ b/calamari_ocr/ocr/predict/params.py
@@ -95,6 +95,7 @@ class PredictionResult:
 
         self.prediction.avg_char_probability = 0
 
+        last_p = None
         for n, p in enumerate(self.prediction.positions):
             for c in p.chars:
                 c.char = codec.code2char[c.label]
@@ -111,7 +112,7 @@ class PredictionResult:
 
             if n == len(self.prediction.positions) - 1:
                 line_len = out_to_in_trans(self.logits.shape[0])
-                p.global_end_ext = min(line_len, ceil((line_len + p.global_end + p_len) / 2))
+                p.global_end_ext = min(line_len - 1, ceil((line_len + p.global_end + p_len) / 2))
 
             if len(p.chars) > 0:
                 self.prediction.avg_char_probability += p.chars[0].probability

--- a/calamari_ocr/ocr/voting/confidence_voter.py
+++ b/calamari_ocr/ocr/voting/confidence_voter.py
@@ -38,6 +38,8 @@ class MergeableCharacter:
         self.p = p
         self.start = start
         self.stop = stop
+        self.start_ext = start_ext
+        self.stop_ext = stop_ext
 
     def merge(self, char, p, start, stop, start_ext, stop_ext):
         assert self.char == char

--- a/calamari_ocr/ocr/voting/confidence_voter.py
+++ b/calamari_ocr/ocr/voting/confidence_voter.py
@@ -33,17 +33,19 @@ def find_voters_with_most_frequent_length(sync, voters):
 
 
 class MergeableCharacter:
-    def __init__(self, char, p, start, stop):
+    def __init__(self, char, p, start, stop, start_ext, stop_ext):
         self.char = char
         self.p = p
         self.start = start
         self.stop = stop
 
-    def merge(self, char, p, start, stop):
+    def merge(self, char, p, start, stop, start_ext, stop_ext):
         assert self.char == char
         self.p += p
         self.start = min(start, self.start)
         self.stop = max(stop, self.stop)
+        self.start_ext = min(start_ext, self.start_ext)
+        self.stop_ext = max(stop_ext, self.stop_ext)
 
 
 def perform_conf_vote(voters):
@@ -71,9 +73,23 @@ def perform_conf_vote(voters):
                 pos = voters[voter_id]["positions"][idx]
                 for k, p in alts.items():
                     if k in c_p:
-                        c_p[k].merge(k, p / len(actual_voters), pos.global_start, pos.global_end)
+                        c_p[k].merge(
+                            k,
+                            p / len(actual_voters),
+                            pos.global_start,
+                            pos.global_end,
+                            pos.global_start_ext,
+                            pos.global_end_ext,
+                        )
                     else:
-                        c_p[k] = MergeableCharacter(k, p / len(actual_voters), pos.global_start, pos.global_end)
+                        c_p[k] = MergeableCharacter(
+                            k,
+                            p / len(actual_voters),
+                            pos.global_start,
+                            pos.global_end,
+                            pos.global_start_ext,
+                            pos.global_end_ext,
+                        )
 
             chars = sorted(c_p.values(), key=lambda v: -v.p)
             final_result.append(chars)
@@ -138,6 +154,8 @@ class ConfidenceVoter(Voter):
             if len(voted_pos) > 0:
                 pos.global_start = voted_pos[0].start
                 pos.global_end = voted_pos[0].stop
+                pos.global_start_ext = voted_pos[0].start_ext
+                pos.global_end_ext = voted_pos[0].stop_ext
                 sentence += voted_pos[0].char
 
         prediction_out.sentence = sentence

--- a/calamari_ocr/scripts/predict.py
+++ b/calamari_ocr/scripts/predict.py
@@ -141,8 +141,8 @@ def run(args: PredictArgs):
 
         avg_sentence_confidence += prediction.avg_char_probability
         if args.verbose:
-            lr = "\u202A\u202B"
-            logger.info("{}: '{}{}{}'".format(meta["id"], lr[get_base_level(sentence)], sentence, "\u202C"))
+            lr = "\u202a\u202b"
+            logger.info("{}: '{}{}{}'".format(meta["id"], lr[get_base_level(sentence)], sentence, "\u202c"))
 
         output_dir = args.output_dir if args.output_dir else os.path.dirname(prediction.line_path)
 

--- a/calamari_ocr/utils/output_to_input_transformer.py
+++ b/calamari_ocr/utils/output_to_input_transformer.py
@@ -15,7 +15,7 @@ class OutputToInputTransformer:
             else:
                 self.processors.extend(proc)
 
-        self.processors = list(filter(lambda p: isinstance(p, ImageProcessor), self.processors))
+        self.processors = list(filter(lambda p: isinstance(p, ImageProcessor), self.processors))[::-1]
 
     def local_to_global(self, x, model_factor, data_proc_params):
         assert model_factor >= 1  # Should never be < 0, this would mean, that the network increases the size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ calamari-dataset-statistics = "calamari_ocr.scripts.dataset_statistics:main"
 test = [
      "pytest",
      "pytest-cov",
-     "pytest-isolate",
+     "pytest-isolate ; python_version >= '3.9'",
+     "pytest-isolate (<0.0.4) ; python_version <'3.9'",
      "pytest-xdist",
      "flake8",
 ]


### PR DESCRIPTION
This PR improves the generation of word/glyph IDs, updates the CLI option for better output precision and fixes word/glyph positions.

#### Changes
- Word ID: Now resets for each line. To ensure uniqueness, the word counter is concatenated with the line ID, starting from 1 in the format: <line_id>_w<word_counter>
- Glyph ID: Now resets after each word and starts from 1, following the format: <line_id>_w<word_counter>_g<glyph_counter>
- CLI Option Update:
    - The option `--data.output_glyphs` is replaced with `--data.output_precision`.
    - Accepted values: LINES, WORDS, GLYPHS (default: LINES).
-  Fix Glyph/Word bounding boxes @andbue 